### PR TITLE
Fixed the delay on child animate in

### DIFF
--- a/robojumperSquadSelect/Src/robojumperSquadSelect/Classes/robojumper_UISquadSelect.uc
+++ b/robojumperSquadSelect/Src/robojumperSquadSelect/Classes/robojumper_UISquadSelect.uc
@@ -1250,7 +1250,7 @@ function AnimateChildPanels()
 		// Screens own their recursive children. Explicitly check here!
 		if (ChildPanels[i].ParentPanel == self)
 		{
-			ChildPanels[i].AnimateIn();
+			ChildPanels[i].AnimateIn(0);
 		}
 	}
 }


### PR DESCRIPTION
This change negates the default list-like `AnimateIn` behaviour in `UIPanel`. I think this is needed even with the CHL fix because it makes no sense to animate in panels in sequential order - they should start animating in all together at the same time