### PR TITLE
Add option to use HQPRES for Training Center screen

### DIFF
--- a/robojumperSquadSelect/Config/XComrobojumperSquadSelect.ini
+++ b/robojumperSquadSelect/Config/XComrobojumperSquadSelect.ini
@@ -12,6 +12,10 @@
 +ClassesExcemptFromRankFiltering="ChiefEngineer"
 +ClassesExcemptFromRankFiltering="CentralOfficer"
 
+; force use of HQPRES to display the Training Center UI - useful if
+; a mod overrides the default promotion screen using the Community
+; Highlander hook
+;bUseHighlanderForPromotionUI=true
 
 [robojumperSquadSelect.robojumper_UISquadSelect_StatsPanel]
 +StatIcons=(Stat=eStat_HP, Icon="img:///UILibrary_robojumperSquadSelect.Stats.icon_health")

--- a/robojumperSquadSelect/Src/robojumperSquadSelect/Classes/robojumper_UISquadSelect_SkillsPanel.uc
+++ b/robojumperSquadSelect/Src/robojumperSquadSelect/Classes/robojumper_UISquadSelect_SkillsPanel.uc
@@ -14,6 +14,10 @@ var config array<name> ClassesExcemptFromRankFiltering;
 // for alternative skill trees, specifiy rank 0 abilities here to hide them if the user wants to
 var config array<name> AdditionalRankZeroAbilities;
 
+// Issue #10: Forces use of HQPRES to display the Training Center screen in case a
+// mod overrides the default one.
+var config bool bUseHighlanderForPromotionUI;
+
 struct AbilityColorData
 {
 	var X2AbilityTemplate Template;
@@ -267,8 +271,15 @@ simulated function OnTrainingCenterButtonClicked(UIButton Button)
 	{
 		if( FacilityState.GetMyTemplateName() == 'RecoveryCenter' && !FacilityState.IsUnderConstruction() )
 		{
-			PromotionUI = UIArmory_PromotionHero(Movie.Stack.Push(Spawn(class'UIArmory_PromotionHero', self), Movie.Pres.Get3DMovie()));
-			PromotionUI.InitPromotion(GetUnit().GetReference(), false);
+			if (bUseHighlanderForPromotionUI)
+			{
+				`HQPRES.ShowPromotionUI(GetUnit().GetReference());
+			}
+			else
+			{
+				PromotionUI = UIArmory_PromotionHero(Movie.Stack.Push(Spawn(class'UIArmory_PromotionHero', self), Movie.Pres.Get3DMovie()));
+				PromotionUI.InitPromotion(GetUnit().GetReference(), false);
+			}
 			return;
 		}
 	}


### PR DESCRIPTION
The Community Highlander now has a hook in `HQPRES.ShowPromotionUI()` that allows mods to override the screen used for promotions and the Training Center. This change allows mods to force Squad Select to use that function when going to the Training Center so the correct screen is
displayed (they may override the base game hero promotion screen with New Promotion Screen By Default for example).

Resolves #10.