### PR TITLE
Allow controller users to directly access weapon's upgrade screen.

### DIFF
--- a/robojumperSquadSelect/Localization/robojumperSquadSelect.int
+++ b/robojumperSquadSelect/Localization/robojumperSquadSelect.int
@@ -26,6 +26,7 @@ strShowMeTheSkills=Show Me The Skills
 strShowStats=Show Me The Stats
 strSkipInitialAbilities=Skip Initial Abilities
 strAutofillSquad=Autofill Squad
+strOpenWeaponUpgradeWithController=Open Weapon Upgrade With Controller
 
 strDisallowInfiniteScrolling=Disallow Infinite Scrolling
 strSkipIntro=Skip Intro

--- a/robojumperSquadSelect/Src/robojumperSquadSelect/Classes/robojumper_SquadSelectConfig.uc
+++ b/robojumperSquadSelect/Src/robojumperSquadSelect/Classes/robojumper_SquadSelectConfig.uc
@@ -4,12 +4,14 @@ class robojumper_SquadSelectConfig extends Object config(robojumperSquadSelect_N
 
 var config bool bShowWeaponUpgradeIcons, bSkipSecondaryUpgradeIconsAvailable, bShowBGImages, bShowMeTheSkills, bSkipInitialAbilities, bAutofillSquad, bShowStats, bDisallowInfiniteScrolling, bSkipIntro;
 var config bool bHideTrainingCenterButton;
+var config bool bOpenWeaponUpgradeWithController;
 
 var config int iSquadSize;
 var config int iVersion;
 
 var bool bShowWeaponUpgradeIcons_def, bSkipSecondaryUpgradeIconsAvailable_def, bShowBGImages_def, bShowMeTheSkills_def, bSkipInitialAbilities_def, bAutofillSquad_def, bShowStats_def, bDisallowInfiniteScrolling_def, bSkipIntro_def;
 var bool bHideTrainingCenterButton_def;
+var bool bOpenWeaponUpgradeWithController_def;
 
 var int iVersion_def;
 
@@ -31,6 +33,7 @@ static function Initialize()
 		DefaultObj.bDisallowInfiniteScrolling = default.bDisallowInfiniteScrolling_def;
 		DefaultObj.bSkipIntro = default.bSkipIntro_def;
 		DefaultObj.bHideTrainingCenterButton = default.bHideTrainingCenterButton_def;
+		DefaultObj.bOpenWeaponUpgradeWithController = default.bOpenWeaponUpgradeWithController_def;
 		// messes with LW2
 		if (!class'X2DownloadableContentInfo_robojumperSquadSelect'.default.bDontTouchSquadSize)
 		{
@@ -107,6 +110,11 @@ static function bool HideTrainingCenterButton()
 	return default.bHideTrainingCenterButton;	
 }
 
+static function bool OpenWeaponUpgradeWithController()
+{
+	return default.bOpenWeaponUpgradeWithController;
+}
+
 static function bool IsCHHLMinVersionInstalled(int iMajor, int iMinor)
 {
 	local X2StrategyElementTemplate VersionTemplate;
@@ -136,6 +144,7 @@ defaultproperties
 	bDisallowInfiniteScrolling_def=false
 	bSkipIntro_def=false
 	bHideTrainingCenterButton_def=false
+	bOpenWeaponUpgradeWithController_def=false
 
 	iVersion_def=1
 }

--- a/robojumperSquadSelect/Src/robojumperSquadSelect/Classes/robojumper_SquadSelect_UISL_MCM.uc
+++ b/robojumperSquadSelect/Src/robojumperSquadSelect/Classes/robojumper_SquadSelect_UISL_MCM.uc
@@ -11,6 +11,7 @@ var localized string strGroupTitle;
 
 var localized string strShowWeaponUpgradeIcons, strSkipSecondaryUpgradeIconsAvailable, strShowBGImages, strShowMeTheSkills, strSkipInitialAbilities, strAutofillSquad, strShowStats, strDisallowInfiniteScrolling, strSkipIntro;
 var localized string strHideTrainingCenterButton;
+var localized string strOpenWeaponUpgradeWithController;
 
 var localized string strSquadSize;
 var config int iSquadSizeMin, iSquadSizeMax;
@@ -20,6 +21,7 @@ var config array<name> SpawnPointFixingMods;
 
 var bool bShowWeaponUpgradeIcons, bSkipSecondaryUpgradeIconsAvailable, bShowBGImages, bShowMeTheSkills, bSkipInitialAbilities, bAutofillSquad, bShowMeTheStats, bDisallowInfiniteScrolling, bSkipIntro;
 var bool bHideTrainingCenterButton;
+var bool bOpenWeaponUpgradeWithController;
 
 
 var int ch_iMaxSoldiers;
@@ -34,6 +36,7 @@ const AUTO_FILL_SQUAD = 'autofillSquad';
 const DISALLOW_INFINITE_SCROLL = 'disallowScrolling';
 const SKIP_INTRO = 'skipIntro';
 const HIDE_TRAINING_CENTER = 'hideTrainingCenter';
+const OPEN_WEAPON_UPGRADE_WITH_CONTROLLER = 'openWeaponUpgradeWithController';
 
 event OnInit(UIScreen Screen)
 {
@@ -62,6 +65,7 @@ simulated function ClientModCallback(MCM_API_Instance ConfigAPI, int GameMode)
 	bAutofillSquad = class'robojumper_SquadSelectConfig'.static.ShouldAutoFillSquad();
 	bDisallowInfiniteScrolling = class'robojumper_SquadSelectConfig'.static.DisAllowInfiniteScrolling();
 	bHideTrainingCenterButton = class'robojumper_SquadSelectConfig'.static.HideTrainingCenterButton();
+	bOpenWeaponUpgradeWithController = class'robojumper_SquadSelectConfig'.static.OpenWeaponUpgradeWithController();
 
 	ch_iMaxSoldiers = class'robojumper_SquadSelectConfig'.static.GetSquadSize();
 
@@ -83,6 +87,7 @@ simulated function ClientModCallback(MCM_API_Instance ConfigAPI, int GameMode)
 	
 	Group.AddCheckbox(DISALLOW_INFINITE_SCROLL, strDisallowInfiniteScrolling, "", bDisallowInfiniteScrolling, , CheckboxSaveHandler);
 
+	Group.AddCheckbox(OPEN_WEAPON_UPGRADE_WITH_CONTROLLER, strOpenWeaponUpgradeWithController, "", bOpenWeaponUpgradeWithController, , CheckboxSaveHandler);
 	
 	if (!class'X2DownloadableContentInfo_robojumperSquadSelect'.default.bDontTouchSquadSize)
 	{
@@ -133,6 +138,9 @@ simulated function CheckboxSaveHandler(MCM_API_Setting _Setting, bool _SettingVa
 		case SKIP_INTRO:
 			bSkipIntro = _SettingValue;
 			break;
+		case OPEN_WEAPON_UPGRADE_WITH_CONTROLLER:
+			bOpenWeaponUpgradeWithController = _SettingValue;
+			break;
 		default:
 			assert(false);
 	}
@@ -158,6 +166,7 @@ simulated function SaveButtonClicked(MCM_API_SettingsPage Page)
 	DefObj.bHideTrainingCenterButton = bHideTrainingCenterButton;
 	DefObj.bDisallowInfiniteScrolling = bDisallowInfiniteScrolling;
 	DefObj.bSkipIntro = bSkipIntro;
+	DefObj.bOpenWeaponUpgradeWithController = bOpenWeaponUpgradeWithController;
 	DefObj.iSquadSize = ch_iMaxSoldiers;
 	class'robojumper_SquadSelectConfig'.static.StaticSaveConfig();
 	// internally guarded

--- a/robojumperSquadSelect/Src/robojumperSquadSelect/Classes/robojumper_UISquadSelect_ListItem.uc
+++ b/robojumperSquadSelect/Src/robojumperSquadSelect/Classes/robojumper_UISquadSelect_ListItem.uc
@@ -666,12 +666,45 @@ simulated function OnClickedEditUnitButton()
 	
 	if( XComHQ.Squad[SquadScreen.m_iSelectedSlot].ObjectID > 0 )
 	{
+		// If the X button was clicked, and OpenWeaponUpgradeWithController is true, we will either :
+		// 1A.] Open a primary weapon's upgrade screen, if one was selected and it is upgradeable.
+		// 1B.] Open a soldier's menu, if anything else was selected.
+		if (`ISCONTROLLERACTIVE && class'robojumper_SquadSelectConfig'.static.OpenWeaponUpgradeWithController() && OnClickedEditWeaponUpgrade())
+		{
+			return;
+		}
+
 		//UISquadSelect(Screen).bDirty = true;
 		SetDirty(true);
 //		SquadScreen.SnapCamera();
 		`HQPRES.UIArmory_MainMenu(XComHQ.Squad[SquadScreen.m_iSelectedSlot]);//, 'PreM_CustomizeUI', 'PreM_SwitchToSoldier', 'PreM_GoToLineup', 'PreM_CustomizeUI_Off', 'PreM_SwitchToLineup');
 //		`XCOMGRI.DoRemoteEvent('PreM_GoToSoldier');
 	}
+}
+
+simulated function bool OnClickedEditWeaponUpgrade()
+{
+	local robojumper_UISquadSelect_EquipItem SelectedEquipItem;
+	local X2WeaponTemplate TheWeaponTemplate;
+	local XComGameState_Item TheItem;
+	
+	SelectedEquipItem = robojumper_UISquadSelect_EquipItem(TheList.GetSelectedItem());
+	
+	// We are only interested in the primary weapon panel.
+	if ((SelectedEquipItem != none) && (SelectedEquipItem.InvSlot == eInvSlot_PrimaryWeapon) && 
+		(SelectedEquipItem.ItemStateRef.ObjectID > 0))
+	{
+		TheItem = XComGameState_Item(`XCOMHISTORY.GetGameStateForObjectID(SelectedEquipItem.ItemStateRef.ObjectID));
+		TheWeaponTemplate = X2WeaponTemplate(TheItem.GetMyTemplate());
+		// We are only interested in weapons with at least 1 weapon upgrade slot.
+		if ((TheWeaponTemplate != none) && (TheWeaponTemplate.NumUpgradeSlots > 0))
+		{
+			SelectedEquipItem.OnClickedUpgradeIcon();
+			return true;
+		}
+	}
+
+	return false;
 }
 
 simulated function OnClickedPromote()


### PR DESCRIPTION
**What it does** :

Adds a Mod Config Menu setting, bOpenWeaponUpgradeWithController, which, if enabled :

- Allows controller users to open a primary weapon's upgrade screen directly by selecting the primary weapon, on the Squad Select UI, then hitting the X button. This is beneficial when using mods like LWotC where you are constantly having to modify weapon upgrades.

**A few notes** :

- Clicking the X button on any other list item still brings up the soldier's menu.
- The primary weapon must have atleast 1 upgrade slot for the upgrade screen to be opened.
- The setting is off by default.